### PR TITLE
Typo fix for bitbucket color on active.

### DIFF
--- a/css/buttons-si.css
+++ b/css/buttons-si.css
@@ -100,7 +100,7 @@
   .btn-bitbucket:hover {
     background-color: #3572B0; }
   .btn-bitbucket:active {
-    background-color: ##4E8AC7; }
+    background-color: #4E8AC7; }
 
 .btn-si-a {
   padding: 25px 15px 25px 65px !important;


### PR DESCRIPTION
Found a double hash on line 103 when defining background-color, removed it.